### PR TITLE
Convert adaptive-feedstock to v1 feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -72,20 +82,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: Adaptive parallel sampling of mathematical functions
 
 Development: https://github.com/python-adaptive/adaptive/
 
-Documentation: http://adaptive.readthedocs.org
+Documentation: http://adaptive.readthedocs.org/
 
 adaptive is an open-source Python library designed to make adaptive
 parallel function evaluation simple. With adaptive you just supply a
@@ -19,7 +19,6 @@ function with its bounds, and it will be evaluated at the "best" points
 in parameter space. With just a few lines of code you can evaluate
 functions on a computing cluster, live-plot the data as it returns,
 and fine-tune the adaptive sampling algorithm.
-
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,5 @@ github:
 provider:
   win: azure
 test: native_and_emulated
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,34 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+[project]
+name = "adaptive-feedstock"
+version = "3.45.4"
+description = "Pixi configuration for conda-forge/adaptive-feedstock"
+authors = ["@conda-forge/adaptive"]
+channels = ["conda-forge"]
+platforms = ['linux-64', 'osx-64', 'win', 'win-64']
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+inspect-all = "inspect_artifacts --all-packages"
+build = "rattler-build build --recipe recipe"
+"build-linux_64_" = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+"inspect-linux_64_" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+
+[feature.smithy.tasks]
+build-locally = "python ./build-locally.py"
+smithy = "conda-smithy"
+rerender = "conda-smithy rerender"
+lint = "conda-smithy lint recipe"
+
+[environments]
+smithy = ["smithy"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,28 +1,31 @@
-{% set name = "adaptive" %}
-{% set version = "1.3.1" %}
-{% set sha256 = "0bfcc906b7381c837148b8e129d98f346a33e7cf805478e10174f62c4011253a" %}
+schema_version: 1
+
+context:
+  name: adaptive
+  version: 1.3.1
+  sha256: 0bfcc906b7381c837148b8e129d98f346a33e7cf805478e10174f62c4011253a
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  fn: {{ version }}.zip
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/adaptive-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/adaptive-${{ version }}.tar.gz
+  sha256: ${{ sha256 }}
+  file_name: ${{ version }}.zip
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
   noarch: python
+  script: ${{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - versioningit
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     # Required dependencies
     - scipy
     - sortedcollections >=1.1
@@ -42,16 +45,13 @@ requirements:
     - matplotlib-base
     - pandas
 
-test:
-  requires:
-    - python {{ python_min }}
-  imports:
-    - adaptive
-
+tests:
+  - python:
+      imports:
+        - adaptive
+      python_version: ${{ python_min }}.*
 about:
-  home: http://github.com/python-adaptive/adaptive
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
   summary: Adaptive parallel sampling of mathematical functions
   description: |
@@ -61,8 +61,9 @@ about:
     in parameter space. With just a few lines of code you can evaluate
     functions on a computing cluster, live-plot the data as it returns,
     and fine-tune the adaptive sampling algorithm.
-  doc_url: http://adaptive.readthedocs.org
-  dev_url: https://github.com/python-adaptive/adaptive/
+  homepage: http://github.com/python-adaptive/adaptive
+  repository: https://github.com/python-adaptive/adaptive/
+  documentation: http://adaptive.readthedocs.org
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts adaptive-feedstock to a v1 recipe and switch the conda build tool to rattler-build.It has been automatically generated with [feedrattler](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.